### PR TITLE
TS test refactor - issue #1

### DIFF
--- a/available/ts/package.json
+++ b/available/ts/package.json
@@ -25,7 +25,7 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "testMatch": [
-      "**/*.(test|spec).(ts|tsx)"
+      "**/*.spec.(ts|tsx)"
     ],
     "globals": {
       "ts-jest": {

--- a/available/ts/src/main.spec.ts
+++ b/available/ts/src/main.spec.ts
@@ -1,4 +1,4 @@
-import { isFoo } from '../main'
+import { isFoo } from './main'
 
 test('isFoo(3, 7) is 10', () => {
   expect(isFoo(3, 7)).toBe(10)


### PR DESCRIPTION
Updated test match to only allow .spec tests in TS starter and removed the __tests__ directory.

This will help retain consistency between the Node and TS starters.